### PR TITLE
Mask db passwords when logging config

### DIFF
--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -29,7 +29,7 @@ class TestCustomExporter(unittest.TestCase):
         # Verify the gauge value was set (requires mocking Prometheus internals)
         # This test assumes the gauge.set() method works as expected.
 
-    @patch('prometheus_client.start_http_server')
+    @patch('db2Prom.prometheus.start_http_server')
     def test_start_exporter(self, mock_start_http_server):
         """
         Test that the Prometheus exporter starts correctly.


### PR DESCRIPTION
## Summary
- add `sanitize_config` to mask password fields in configs
- log sanitized configs to avoid exposing passwords
- test config masking and adjust mocks to patch imported objects

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9ff42b8e08332a44786ffd12cec66