### PR TITLE
Add DB2 start time gauge configuration

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -70,6 +70,18 @@ queries:
           appstate: "$2" # Second column of query result will be set as this label's value
           appname: "$3" # Third column of query result will be set as this label's value
 
+  - name: "DB2 Start Time"
+    runs_on: [] # Query runs on every connection
+    time_interval: 60 # Check every 60 seconds
+    query: |
+      SELECT
+        UNIX_TIMESTAMP(DB2START_TIME) AS start_time
+      FROM TABLE (MON_GET_INSTANCE(-2))
+    gauges:
+      - name: "db2_up_since_seconds"
+        desc: "Unix timestamp when the DB2 instance started"
+        col: 1
+
 ###############################################
 # Connections
 ###############################################

--- a/config.yaml
+++ b/config.yaml
@@ -109,10 +109,22 @@ queries:
       - name: "db2_total_log_used"
         desc: "Total log space used in KB"
         col: 1
-        
+
       - name: "db2_total_log_available"
         desc: "Total log space available in KB"
         col: 2
+
+  - name: "DB2 Start Time"
+    runs_on: []
+    time_interval: 60
+    query: |
+      SELECT
+        UNIX_TIMESTAMP(DB2START_TIME) AS start_time
+      FROM TABLE (MON_GET_INSTANCE(-2))
+    gauges:
+      - name: "db2_up_since_seconds"
+        desc: "Unix timestamp when the DB2 instance started"
+        col: 1
 
 connections:
   - db_host: "192.168.50.253"


### PR DESCRIPTION
## Summary
- expose DB2 instance start time via new `db2_up_since_seconds` gauge
- sample configuration for DB2 start time metric

## Testing
- `PYTHONPATH=. PYENV_VERSION=3.11.12 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa05a3bc788332b53befd764051041