### PR TITLE
Add max_rows parameter for DB2 queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Key features include:
 - **Asynchronous Execution**: Run multiple queries concurrently for optimal performance.
 - **Persistent Connections**: Automatically reconnect to databases if the connection is dropped.
 - **Configuration via YAML**: Easily configure which metrics to export and which databases to connect using YAML files.
+- **Row Limiting**: Prevent runaway result sets by capping rows per query with an optional `max_rows` setting.
 - **Label Sanitization**: Clean DB-sourced label values so they contain only letters, numbers, and underscores. Any character outside `[A-Za-z0-9_]` (e.g., spaces, hyphens, slashes) is replaced with `_`, and values longer than 100 characters are trimmed.
 
 # Changes from db2dexpo
@@ -69,7 +70,17 @@ Install all required packages using pip:
 pip3 install -r requirements.txt
 ```
 
-Check [the example config YAML](config.example.yaml) on how to handle multiple databases with different access. Use this example YAML to also make your own config.yaml file, with your queries and gauge metrics.
+Check [the example config YAML](config.example.yaml) on how to handle multiple databases with different access. Each query can optionally include a `max_rows` field to cap the number of rows processed:
+
+```yaml
+- name: "Applications count"
+  time_interval: 15
+  max_rows: 100
+  query: |
+    SELECT ...
+```
+
+Use this example YAML to also make your own `config.yaml` file, with your queries and gauge metrics.
 
 Run the application:
 
@@ -108,7 +119,7 @@ cd db2dexpo/
 ```
 
 
-Check [the example config YAML](config.example.yaml) on how to handle multiple databases with different access. Use this example YAML to also make your own config.yaml file, with your queries and gauge metrics.
+Check [the example config YAML](config.example.yaml) on how to handle multiple databases with different access. Use this example YAML to also make your own `config.yaml` file with custom queries, metrics, and optional `max_rows` limits.
 
 Build Docker image:
 

--- a/app.py
+++ b/app.py
@@ -158,6 +158,7 @@ async def query_set(config_connection, pool, config_query, exporter, default_tim
                 config_query["query"],
                 config_query["name"],
                 timeout=config_query.get("timeout"),
+                max_rows=config_query.get("max_rows"),
             )
             duration = time.perf_counter() - start_time
             exporter.record_query_duration(query_label, duration)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,6 +44,7 @@ queries:
   - name: "Applications count"
     runs_on: [] # Query runs on every connection
     time_interval: 15
+    max_rows: 100 # Limit the number of rows processed
     query: |
       SELECT
       count(*) as count,

--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,7 @@ queries:
   - name: "Applications count"
     runs_on: []
     time_interval: 15
+    max_rows: 100
     query: |
       SELECT
       count(*) as count,

--- a/tests/test_db2.py
+++ b/tests/test_db2.py
@@ -1,7 +1,24 @@
 import unittest
 import asyncio
 import time
+import sys
+import types
 from unittest.mock import patch, MagicMock
+
+# Provide a minimal mock for the ``ibm_db`` module so the tests can run
+# without the actual dependency being installed.
+ibm_db_mock = types.SimpleNamespace(
+    SQL_ATTR_INFO_PROGRAMNAME=0,
+    SQL_ATTR_INFO_WRKSTNNAME=0,
+    SQL_ATTR_INFO_ACCTSTR=0,
+    SQL_ATTR_INFO_APPLNAME=0,
+    pconnect=MagicMock(),
+    exec_immediate=MagicMock(),
+    fetch_tuple=MagicMock(),
+    close=MagicMock(),
+)
+sys.modules.setdefault("ibm_db", ibm_db_mock)
+
 from db2Prom.db2 import Db2Connection
 
 
@@ -59,6 +76,27 @@ class TestDb2Connection(unittest.TestCase):
         )
         db2_conn.conn = "mock_connection"
         result = asyncio.run(db2_conn.execute("SELECT * FROM table", "test_query"))
+        self.assertEqual(result, [[1, "data"]])
+
+    @patch('ibm_db.exec_immediate')
+    @patch('ibm_db.fetch_tuple')
+    def test_execute_query_max_rows(self, mock_fetch_tuple, mock_exec_immediate):
+        """Test that max_rows limits the number of returned rows."""
+        mock_exec_immediate.return_value = "mock_statement"
+        mock_fetch_tuple.side_effect = [[1, "data"], [2, "data2"], None]
+        mock_exporter = MagicMock()
+        db2_conn = Db2Connection(
+            db_name="test_db",
+            db_hostname="localhost",
+            db_port="50000",
+            db_user="user",
+            db_passwd="pass",
+            exporter=mock_exporter,
+        )
+        db2_conn.conn = "mock_connection"
+        result = asyncio.run(
+            db2_conn.execute("SELECT * FROM table", "test_query", max_rows=1)
+        )
         self.assertEqual(result, [[1, "data"]])
 
     @patch('ibm_db.exec_immediate')

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -1,5 +1,27 @@
 import unittest
+import unittest
+import sys
+import types
 from unittest.mock import patch, MagicMock
+
+# Stub prometheus_client so tests do not require the real dependency
+class _Gauge:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def labels(self, **kwargs):
+        return self
+
+    def set(self, value):
+        pass
+
+prom_client_stub = types.SimpleNamespace(
+    start_http_server=MagicMock(),
+    Gauge=_Gauge,
+    REGISTRY=types.SimpleNamespace(_names_to_collectors={}),
+)
+sys.modules.setdefault("prometheus_client", prom_client_stub)
+
 from db2Prom.prometheus import CustomExporter
 from prometheus_client import Gauge
 


### PR DESCRIPTION
## Summary
- add optional `max_rows` parameter to `Db2Connection.execute` to limit row retrieval
- allow query configuration to pass `max_rows` when executing queries and expose in sample configs
- document `max_rows` usage and expanded instructions in README
- test coverage for `max_rows` and provide local stubs for optional dependencies

## Testing
- `python3 -m unittest discover -s tests -p 'test_*.py' -v`


------
https://chatgpt.com/codex/tasks/task_e_68aa20136be88332bec9c40ae9304e5f