### PR TITLE
Add optional console logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ machines can use that hostname to scrape the metrics endpoint.
 
 Set DB2DEXPO_LOG_LEVEL to DEBUG to show query executions and metric updates.
 
+Console logging can be disabled by setting `log_console: false` in the
+`global_config` section of `config.yaml`.
+
 Example output of application startup:
 
 ```text

--- a/app.py
+++ b/app.py
@@ -59,9 +59,9 @@ def sanitize_label_value(value, max_length: int = MAX_LABEL_LENGTH) -> str:
 
     return sanitized
 
-def setup_logging(log_path, log_level):
+def setup_logging(log_path, log_level, log_console=True):
     """
-    Set up logging with rotating file handlers.
+    Set up logging with rotating file handlers and optional console output.
     """
     # Create log directory if it doesn't exist
     os.makedirs(log_path, exist_ok=True)
@@ -83,6 +83,12 @@ def setup_logging(log_path, log_level):
     error_handler.setLevel(logging.ERROR)
     error_handler.setFormatter(formatter)
     logger.addHandler(error_handler)
+
+    # Optional console handler
+    if log_console:
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
 
 def db2_instance_connection(config_connection, exporter):
     """
@@ -387,10 +393,11 @@ if __name__ == '__main__':
         log_path = global_config.get("log_path", "/path/to/logs/")
         port = global_config.get("port", 9844)
         retry_conn_interval = global_config.get("retry_conn_interval", 60)  # Default to 60 if not explicitly set
+        log_console = global_config.get("log_console", True)
         logging.info(f"Retry connection interval: {retry_conn_interval}")  # Logging retry connection interval
-        
+
         # Setup logging configuration
-        setup_logging(log_path, log_level)
+        setup_logging(log_path, log_level, log_console)
         logging.info("Configuration file loaded successfully.")
 
         # Validate global configuration variables

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ global_config:
   retry_conn_interval: 60
   default_time_interval: 15
   log_path: "logs/"
+  log_console: true
   port: 9844
 
 queries:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -49,9 +49,10 @@ from db2Prom.db2 import Db2Connection
 class TestApp(unittest.TestCase):
 
     @patch('os.makedirs')
+    @patch('logging.StreamHandler')
     @patch('app.RotatingFileHandler')
     @patch('logging.getLogger')
-    def test_setup_logging(self, mock_get_logger, mock_rotating_file_handler, mock_makedirs):
+    def test_setup_logging(self, mock_get_logger, mock_rotating_file_handler, mock_stream_handler, mock_makedirs):
         """
         Test that logging is set up correctly.
         """
@@ -59,12 +60,14 @@ class TestApp(unittest.TestCase):
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
 
-        # Mock the RotatingFileHandler to avoid actual file creation
+        # Mock the handlers to avoid actual file creation and console output
         mock_handler = MagicMock()
         mock_rotating_file_handler.return_value = mock_handler
+        mock_stream = MagicMock()
+        mock_stream_handler.return_value = mock_stream
 
         # Call the function
-        setup_logging("/fake/log/path", "INFO")
+        setup_logging("/fake/log/path", "INFO", True)
 
         # Verify the directory was created
         mock_makedirs.assert_called_once_with("/fake/log/path", exist_ok=True)
@@ -78,7 +81,8 @@ class TestApp(unittest.TestCase):
         )
 
         # Verify the handlers were added to the logger
-        self.assertEqual(mock_logger.addHandler.call_count, 2)  # Main log handler and error log handler
+        self.assertEqual(mock_logger.addHandler.call_count, 3)  # Main, error, and console handlers
+        mock_stream_handler.assert_called_once()
 
     @patch('app.Db2Connection')
     def test_db2_instance_connection(self, mock_db2_connection):


### PR DESCRIPTION
## Summary
- allow optional console logging via new `log_console` config setting
- attach `StreamHandler` with shared formatter to logging setup
- document console logging toggle and update tests

## Testing
- `PYENV_VERSION=3.10.17 python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa23173fa0833297e8d28fc47f5f50