### PR TITLE
Support parameterized DB2 queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Key features include:
 - **Persistent Connections**: Automatically reconnect to databases if the connection is dropped.
 - **Configuration via YAML**: Easily configure which metrics to export and which databases to connect using YAML files.
 - **Row Limiting**: Prevent runaway result sets by capping rows per query with an optional `max_rows` setting.
+- **Parameterized Queries**: Safely pass parameters to SQL statements using bound placeholders.
 - **Label Sanitization**: Clean DB-sourced label values so they contain only letters, numbers, and underscores. Any character outside `[A-Za-z0-9_]` (e.g., spaces, hyphens, slashes) is replaced with `_`, and values longer than 100 characters are trimmed.
 
 # Changes from db2dexpo
@@ -73,12 +74,16 @@ pip3 install -r requirements.txt
 Check [the example config YAML](config.example.yaml) on how to handle multiple databases with different access. Each query can optionally include a `max_rows` field to cap the number of rows processed:
 
 ```yaml
-- name: "Applications count"
+- name: "Employee count"
   time_interval: 15
   max_rows: 100
   query: |
-    SELECT ...
+    SELECT COUNT(*) FROM employees WHERE department = ?
+  params:
+    - "SALES"
 ```
+
+The values listed under `params` are bound to the `?` placeholders in the SQL statement.
 
 Use this example YAML to also make your own `config.yaml` file, with your queries and gauge metrics.
 

--- a/app.py
+++ b/app.py
@@ -163,6 +163,7 @@ async def query_set(config_connection, pool, config_query, exporter, default_tim
             res = await conn.execute(
                 config_query["query"],
                 config_query["name"],
+                config_query.get("params"),
                 timeout=config_query.get("timeout"),
                 max_rows=config_query.get("max_rows"),
             )

--- a/config.yaml
+++ b/config.yaml
@@ -28,6 +28,20 @@ queries:
         extra_labels:
           time: "seconds"
 
+  - name: "Employees in department"
+    runs_on: []
+    time_interval: 15
+    query: |
+      SELECT COUNT(*)
+      FROM employees
+      WHERE department = ?
+    params:
+      - "SALES"
+    gauges:
+      - name: "db2_employees_in_dept"
+        desc: "Employees in a department"
+        col: 1
+
   - name: "Applications count"
     runs_on: []
     time_interval: 15

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import sys
+import sys
 import types
 import pytest
 
@@ -14,7 +15,8 @@ def _dummy(*args, **kwargs):  # pragma: no cover - simple placeholder
     return object()
 
 ibm_db.pconnect = _dummy
-ibm_db.exec_immediate = _dummy
+ibm_db.prepare = _dummy
+ibm_db.execute = _dummy
 ibm_db.fetch_tuple = lambda stmt: ()
 ibm_db.close = lambda conn: True
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,7 +30,8 @@ ibm_db_stub = types.SimpleNamespace(
     SQL_ATTR_INFO_ACCTSTR=0,
     SQL_ATTR_INFO_APPLNAME=0,
     pconnect=MagicMock(),
-    exec_immediate=MagicMock(),
+    prepare=MagicMock(),
+    execute=MagicMock(),
     fetch_tuple=MagicMock(),
     close=MagicMock(),
 )
@@ -213,7 +214,7 @@ class TestApp(unittest.TestCase):
         with self.assertRaises(asyncio.CancelledError):
             asyncio.run(query_set(config_connection, pool, config_query, exporter, 1))
 
-        conn.execute.assert_awaited_with("sql", "q", timeout=None, max_rows=5)
+        conn.execute.assert_awaited_with("sql", "q", None, timeout=None, max_rows=5)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Allow passing parameters to `Db2Connection.execute` and run prepared statements with ibm_db
- Pass query parameters from app configuration to execution
- Update tests to match new call signature and parameter handling
- Demonstrate parameterized queries in `README.md` and `config.yaml`

## Testing
- `venv/bin/python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa24602b688332a18c7182cc699ff7