### PR TITLE
Reset DB2 connection after query errors

### DIFF
--- a/db2Prom/db2.py
+++ b/db2Prom/db2.py
@@ -81,7 +81,8 @@ class Db2Connection:
                     f"[{self.connection_string_print}] [{name}] execution timed out"
                 )
                 self.exporter.set_gauge("db2_query_timeout", 1, {"query": name})
-                return [[]]
+                self.conn = None
+                raise
 
             logger.debug(f"[{self.connection_string_print}] [{name}] executed")
             rows = []
@@ -94,7 +95,8 @@ class Db2Connection:
             return rows
         except Exception as e:
             logger.warning(f"[{self.connection_string_print}] [{name}] failed to execute: {e}")
-            return [[]]
+            self.conn = None
+            raise
 
     def close(self):
         """


### PR DESCRIPTION
## Summary
- Reset the DB2 connection and re-raise on query timeout or execution failure
- Test that connection resets and errors propagate on timeout and execution failure

## Testing
- `PYENV_VERSION=3.10.17 pyenv exec python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa29d6b20883328c9a338dd2e44f12