### PR TITLE
refactor: remove logging basicConfig call

### DIFF
--- a/db2Prom/prometheus.py
+++ b/db2Prom/prometheus.py
@@ -3,8 +3,6 @@ import logging
 import socket
 import time
 
-# Initialize logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 INVALID_LABEL_STR = "-"


### PR DESCRIPTION
## Summary
- remove direct `logging.basicConfig` call in the Prometheus exporter so logging is configured by the host application

## Testing
- `PYTHONPATH=. PYENV_VERSION=3.10.17 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2b3e10cc833290262edbcae279cb