### PR TITLE
Stream DB2 query results incrementally

### DIFF
--- a/app.py
+++ b/app.py
@@ -160,13 +160,16 @@ async def query_set(config_connection, pool, config_query, exporter, default_tim
 
             # Execute query and export metrics
             start_time = time.perf_counter()
-            res = await conn.execute(
-                config_query["query"],
-                config_query["name"],
-                config_query.get("params"),
-                timeout=config_query.get("timeout"),
-                max_rows=config_query.get("max_rows"),
-            )
+            res = [
+                row
+                async for row in conn.execute(
+                    config_query["query"],
+                    config_query["name"],
+                    config_query.get("params"),
+                    timeout=config_query.get("timeout"),
+                    max_rows=config_query.get("max_rows"),
+                )
+            ]
             duration = time.perf_counter() - start_time
             exporter.record_query_duration(query_label, duration)
             g_counter = 0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -169,7 +169,11 @@ class TestApp(unittest.TestCase):
         pool = MagicMock()
         conn = MagicMock()
         conn.connect = MagicMock()
-        conn.execute = AsyncMock(return_value=[(1, "bad label!!")])
+
+        async def gen_rows():
+            yield (1, "bad label!!")
+
+        conn.execute = MagicMock(return_value=gen_rows())
         pool.acquire = AsyncMock(return_value=conn)
         pool.release = MagicMock()
 
@@ -200,7 +204,11 @@ class TestApp(unittest.TestCase):
         pool = MagicMock()
         conn = MagicMock()
         conn.connect = MagicMock()
-        conn.execute = AsyncMock(return_value=[[1]])
+
+        async def gen_rows():
+            yield [1]
+
+        conn.execute = MagicMock(return_value=gen_rows())
         pool.acquire = AsyncMock(return_value=conn)
         pool.release = MagicMock()
 
@@ -215,7 +223,7 @@ class TestApp(unittest.TestCase):
         with self.assertRaises(asyncio.CancelledError):
             asyncio.run(query_set(config_connection, pool, config_query, exporter, 1))
 
-        conn.execute.assert_awaited_with("sql", "q", None, timeout=None, max_rows=5)
+        conn.execute.assert_called_with("sql", "q", None, timeout=None, max_rows=5)
 
     @patch('app.ConnectionPool')
     @patch('app.query_set', new_callable=AsyncMock)


### PR DESCRIPTION
## Summary
- Convert DB2 `execute` into an async generator to stream rows incrementally
- Adapt query execution in `app.py` to consume rows via async iteration
- Update tests to iterate over the async generator

## Testing
- `/root/.pyenv/versions/3.10.17/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa2c3188c0833294ff8ce94965a062