### PR TITLE
Avoid mutable default for metric labels

### DIFF
--- a/db2Prom/prometheus.py
+++ b/db2Prom/prometheus.py
@@ -61,13 +61,19 @@ class CustomExporter:
             for q in query_names:
                 self.query_last_success[q] = 0.0
 
-    def create_gauge(self, metric_name: str, metric_desc: str, metric_labels: list = []):
-        """
-        Create a new Prometheus gauge metric.
-        """
+    def create_gauge(
+        self,
+        metric_name: str,
+        metric_desc: str,
+        metric_labels: list | None = None,
+    ):
+        """Create a new Prometheus gauge metric."""
+        metric_labels = metric_labels or []
         try:
             if metric_labels:
-                self.metric_dict[metric_name] = Gauge(metric_name, metric_desc, metric_labels)
+                self.metric_dict[metric_name] = Gauge(
+                    metric_name, metric_desc, metric_labels
+                )
             else:
                 self.metric_dict[metric_name] = Gauge(metric_name, metric_desc)
             logger.info(f"[GAUGE] [{metric_name}] created")


### PR DESCRIPTION
## Summary
- refactor `create_gauge` to use `metric_labels: list | None = None`
- initialize labels list inside `create_gauge` to prevent shared mutable defaults

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa31f18ce48332923b6d77cf8f870f