### PR TITLE
Use dedicated CollectorRegistry for metrics

### DIFF
--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -1,26 +1,5 @@
 import unittest
-import unittest
-import sys
-import types
 from unittest.mock import patch, MagicMock
-
-# Stub prometheus_client so tests do not require the real dependency
-class _Gauge:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def labels(self, **kwargs):
-        return self
-
-    def set(self, value):
-        pass
-
-prom_client_stub = types.SimpleNamespace(
-    start_http_server=MagicMock(),
-    Gauge=_Gauge,
-    REGISTRY=types.SimpleNamespace(_names_to_collectors={}),
-)
-sys.modules.setdefault("prometheus_client", prom_client_stub)
 
 from db2Prom.prometheus import CustomExporter
 from prometheus_client import Gauge
@@ -57,14 +36,18 @@ class TestCustomExporter(unittest.TestCase):
         """Exporter binds to the OS hostname by default."""
         exporter = CustomExporter()
         exporter.start()
-        mock_start_http_server.assert_called_once_with(9877, addr="test-host")
+        mock_start_http_server.assert_called_once_with(
+            9877, addr="test-host", registry=exporter.registry
+        )
 
     @patch('db2Prom.prometheus.start_http_server')
     def test_start_exporter_with_custom_host(self, mock_start_http_server):
         """Exporter binds to a specified host when provided."""
         exporter = CustomExporter(port=9877, host="127.0.0.1")
         exporter.start()
-        mock_start_http_server.assert_called_once_with(9877, addr="127.0.0.1")
+        mock_start_http_server.assert_called_once_with(
+            9877, addr="127.0.0.1", registry=exporter.registry
+        )
 
     def test_query_cache_initialisation_and_record(self):
         """Query names from config initialise cache and metrics."""
@@ -86,6 +69,12 @@ class TestCustomExporter(unittest.TestCase):
         exporter.record_query_duration("q1", 1.23)
         exporter.record_query_success("q1")
         self.assertGreater(exporter.query_last_success["q1"], 0)
+
+    def test_exporters_have_separate_registries(self):
+        """Multiple exporters should not share registries."""
+        exporter1 = CustomExporter()
+        exporter2 = CustomExporter()
+        self.assertIsNot(exporter1.registry, exporter2.registry)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- initialize exporter metrics in its own CollectorRegistry
- handle duplicate metrics and expose registry when starting HTTP server
- refresh Prometheus tests and add coverage for separate registries

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa34e073a48332ae60f2e138607b58