### PR TITLE
Add connection status labels

### DIFF
--- a/db2Prom/prometheus.py
+++ b/db2Prom/prometheus.py
@@ -45,6 +45,7 @@ class CustomExporter:
         self.create_gauge(
             "db2_connection_status",
             "Indicates whether the DB2 database is reachable (1 = reachable, 0 = unreachable)",
+            ["dbhost", "dbname"],
         )
 
         self.create_gauge(

--- a/tests/test_db2.py
+++ b/tests/test_db2.py
@@ -42,7 +42,11 @@ class TestDb2Connection(unittest.TestCase):
         )
         db2_conn.connect()
         self.assertEqual(db2_conn.conn, "mock_connection")
-        mock_exporter.set_gauge.assert_called_with("db2_connection_status", 1)
+        mock_exporter.set_gauge.assert_called_with(
+            "db2_connection_status",
+            1,
+            {"dbhost": "localhost", "dbname": "test_db"},
+        )
 
     @patch('ibm_db.pconnect')
     def test_connect_failure(self, mock_pconnect):
@@ -60,7 +64,11 @@ class TestDb2Connection(unittest.TestCase):
         with self.assertRaises(Exception):
             db2_conn.connect()
         self.assertIsNone(db2_conn.conn)
-        mock_exporter.set_gauge.assert_called_with("db2_connection_status", 0)
+        mock_exporter.set_gauge.assert_called_with(
+            "db2_connection_status",
+            0,
+            {"dbhost": "localhost", "dbname": "test_db"},
+        )
 
     @patch('ibm_db.free_stmt')
     @patch('ibm_db.fetch_tuple')


### PR DESCRIPTION
## Summary
- add `dbhost` and `dbname` labels to `db2_connection_status`
- pass connection labels when updating `db2_connection_status`

## Testing
- `PYTHONPATH=. PYENV_VERSION=3.10.17 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa3a43ce108332b4e244fc5a7249e9