### PR TITLE
Pass full label set to query execution

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -195,7 +195,16 @@ class TestApp(unittest.TestCase):
         }
 
         with self.assertRaises(asyncio.CancelledError):
-            asyncio.run(query_set(config_connection, pool, config_query, exporter, 1))
+            asyncio.run(
+                query_set(
+                    config_connection,
+                    pool,
+                    config_query,
+                    exporter,
+                    1,
+                    {"dbhost", "dbport", "dbname"},
+                )
+            )
 
         # One of the calls should contain the sanitized label from the query result
         self.assertGreaterEqual(exporter.set_gauge.call_count, 1)
@@ -231,7 +240,16 @@ class TestApp(unittest.TestCase):
         }
 
         with self.assertRaises(asyncio.CancelledError):
-            asyncio.run(query_set(config_connection, pool, config_query, exporter, 1))
+            asyncio.run(
+                query_set(
+                    config_connection,
+                    pool,
+                    config_query,
+                    exporter,
+                    1,
+                    {"dbhost", "dbport", "dbname"},
+                )
+            )
 
         conn.execute.assert_called_with("sql", "q", None, timeout=None, max_rows=5)
 
@@ -251,7 +269,16 @@ class TestApp(unittest.TestCase):
         ]
         exporter = MagicMock()
 
-        asyncio.run(main(config_connection, config_queries, exporter, 1, 0))
+        asyncio.run(
+            main(
+                config_connection,
+                config_queries,
+                exporter,
+                1,
+                0,
+                {"dbhost", "dbport", "dbname"},
+            )
+        )
 
         called = {c.args[2]["name"] for c in mock_query_set.call_args_list}
         self.assertEqual(called, {"q1", "q3", "q4"})


### PR DESCRIPTION
## Summary
- Pass the union of connection labels down through `run_all` and `main` to `query_set`
- Accept the complete label set in `query_set` and remove hard-coded labels
- Prefill missing connection labels with the invalid label placeholder before emitting metrics

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa40db86448332b1dad4e6bae145c7