### PR TITLE
Handle unsupported signal handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ You can then open `http://<exporter-host>:9877/` and see the exported metrics.
 
 Ctrl+c will stop the application.
 
+## Platform-specific signal handling
+
+`db2Prom` registers handlers for `SIGINT` and `SIGTERM` using
+`asyncio.loop.add_signal_handler` for graceful shutdown. Some platforms,
+such as the default Windows event loop, do not implement this API. In these
+cases the exporter falls back to `signal.signal` and, if even that is
+unavailable, skips signal registration entirely. This means graceful shutdown
+may not be possible on every platform.
+
 ## Running in Docker
 
 Clone this repo:

--- a/app.py
+++ b/app.py
@@ -432,7 +432,13 @@ async def run_all(
         stop_event.set()
 
     for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, _signal_handler)
+        try:
+            loop.add_signal_handler(sig, _signal_handler)
+        except NotImplementedError:
+            try:
+                signal.signal(sig, lambda s, f: _signal_handler())
+            except (ValueError, AttributeError):
+                logging.debug("Signal handling not supported for %s; skipping.", sig)
 
     tasks = [
         asyncio.create_task(


### PR DESCRIPTION
## Summary
- Catch NotImplementedError when registering signal handlers and fall back to `signal.signal`
- Document platform-specific signal handling limitations

## Testing
- `PYENV_VERSION=3.10.17 python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa4345d3448332b3512bab99f92240