### PR TITLE
Refactor config sanitization to avoid deep copy

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,6 @@ import yaml
 import logging
 import asyncio
 import re
-import copy
 import random
 import time
 from logging.handlers import RotatingFileHandler
@@ -287,17 +286,22 @@ def load_config_yaml(file_str):
         sys.exit(1)
 
 def sanitize_config(config):
+    """Return a copy of the configuration with password fields masked.
+
+    The original configuration is not modified.
     """
-    Return a deep copy of the configuration with password fields masked.
-    """
+
     def mask(item):
         if isinstance(item, dict):
-            return {k: ('******' if 'pass' in k.lower() else mask(v)) for k, v in item.items()}
+            sanitized = {}
+            for k, v in item.items():
+                sanitized[k] = "******" if "pass" in k.lower() else mask(v)
+            return sanitized
         if isinstance(item, list):
             return [mask(i) for i in item]
         return item
 
-    return mask(copy.deepcopy(config))
+    return mask(config)
 
 def get_labels_list(config_connections):
     """

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,7 @@ import types
 from unittest.mock import patch, MagicMock, mock_open, AsyncMock
 import os
 import logging
+import copy
 
 import app as app_module
 # Minimal stubs for external dependencies so tests run without optional packages
@@ -162,6 +163,15 @@ class TestApp(unittest.TestCase):
         self.assertEqual(sanitized["global_config"]["password"], "******")
         # Original config should remain unchanged
         self.assertEqual(config["connections"][0]["db_passwd"], "secret")
+
+    def test_sanitize_config_does_not_mutate_original(self):
+        config = {
+            "connections": [{"db_user": "u", "db_passwd": "secret"}],
+            "global_config": {"password": "another", "foo": "bar"},
+        }
+        original = copy.deepcopy(config)
+        sanitize_config(config)
+        self.assertEqual(config, original)
 
     def test_sanitize_label_value(self):
         # Replaces illegal characters and trims long strings


### PR DESCRIPTION
## Summary
- Drop unnecessary `copy.deepcopy` in `sanitize_config`
- Build sanitized structure directly in helper
- Add regression test ensuring original config isn't mutated

## Testing
- `venv/bin/python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa45331958833289609fa4f0564645