### PR TITLE
Remove redundant timeout gauge setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -342,12 +342,6 @@ def start_prometheus_exporter(config_queries, max_conn_labels, port):
             "Unix timestamp of the last successful DB2 query execution",
             ["query"],
         )
-        # Gauge to track query timeouts
-        custom_exporter.create_gauge(
-            "db2_query_timeout",
-            "Indicates that a query execution has timed out (1 = timeout)",
-            ["query"],
-        )
         custom_exporter.create_counter(
             "db2_query_failures_total",
             "Total number of DB2 query execution failures",

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -26,9 +26,27 @@ class TestCustomExporter(unittest.TestCase):
 
         # Set the gauge value
         exporter.set_gauge("test_gauge", 42, {"label1": "value1", "label2": "value2"})
+        # Verify the gauge value was set
+        value = (
+            exporter.metric_dict["test_gauge"]
+            .labels(label1="value1", label2="value2")
+            ._value.get()
+        )
+        self.assertEqual(value, 42)
 
-        # Verify the gauge value was set (requires mocking Prometheus internals)
-        # This test assumes the gauge.set() method works as expected.
+    def test_query_timeout_gauge_exists_and_updates(self):
+        """Default timeout gauge should be created and allow updates."""
+        exporter = CustomExporter(query_names=["q1"])
+
+        # Gauge created in the constructor
+        self.assertIn("db2_query_timeout", exporter.metric_dict)
+
+        # Update the gauge and verify the value
+        exporter.set_gauge("db2_query_timeout", 1, {"query": "q1"})
+        value = (
+            exporter.metric_dict["db2_query_timeout"].labels(query="q1")._value.get()
+        )
+        self.assertEqual(value, 1)
 
     @patch('db2Prom.prometheus.start_http_server')
     @patch('db2Prom.prometheus.socket.gethostname', return_value='test-host')


### PR DESCRIPTION
## Summary
- Drop duplicate `db2_query_timeout` gauge creation from `start_prometheus_exporter`
- Add tests asserting gauge values and verifying default timeout gauge creation

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa4a15625883328c54778f0fee8da2