### PR TITLE
Use ConfigError for config failures and update tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ibm-db
 prometheus-client
 pyyaml
 asyncio
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -47,6 +47,7 @@ from app import (
     sanitize_label_value,
     query_set,
     main,
+    ConfigError,
 )
 from db2Prom.db2 import Db2Connection
 
@@ -132,6 +133,12 @@ class TestApp(unittest.TestCase):
             exporter=mock_exporter  # Pass the exporter
         )
 
+    def test_db2_instance_connection_missing_field_raises(self):
+        """Missing connection fields should raise ConfigError."""
+        config_connection = {"db_name": "db"}  # Missing other fields
+        with self.assertRaises(ConfigError):
+            db2_instance_connection(config_connection, MagicMock())
+
     def test_load_config_yaml(self):
         """
         Test that the YAML configuration file is loaded correctly.
@@ -152,6 +159,10 @@ class TestApp(unittest.TestCase):
             # Verify the configuration was loaded correctly
             self.assertEqual(config["global_config"]["log_level"], "INFO")
             self.assertEqual(config["global_config"]["default_time_interval"], 15)
+
+    def test_load_config_yaml_missing_file(self):
+        with self.assertRaises(ConfigError):
+            load_config_yaml("nonexistent.yaml")
 
     def test_sanitize_config(self):
         config = {


### PR DESCRIPTION
## Summary
- raise `ConfigError` for configuration issues instead of exiting the process
- catch `ConfigError` at the CLI entry and exit gracefully
- add `pytest` to requirements for running the test suite

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa4b48c02c83329695f80fd4fe7a97